### PR TITLE
Added minimum operating version of Home Assistant

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HASS-BlueCon",
   "render_readme": true,
-  "hide_default_branch": false
+  "hide_default_branch": false,
   "homeassistant": "2024.3.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,4 +2,5 @@
   "name": "HASS-BlueCon",
   "render_readme": true,
   "hide_default_branch": false
+  "homeassistant": "2024.3.0"
 }


### PR DESCRIPTION
Hi @AfonsoFGarcia,

In this PR a modification is sent to add the minimum working version of Home Assistant in the file “hacs.json”.

Checks performed, before sending the PR

- The .json file has been validated and checked 
- It has been tested in Home Assistant to check its operation

![image](https://github.com/user-attachments/assets/f9189366-b632-4990-9393-0c20f4939424)
