### PR TITLE
Upgrade of deprecated lock state consts in home assistant 2025.10

### DIFF
--- a/custom_components/bluecon/lock.py
+++ b/custom_components/bluecon/lock.py
@@ -1,13 +1,7 @@
 import asyncio
 from .const import DEVICE_MANUFACTURER, DOMAIN, CONF_LOCK_STATE_RESET, HASS_BLUECON_VERSION
 from homeassistant.components.lock import LockEntity
-from homeassistant.const import (
-    STATE_JAMMED,
-    STATE_LOCKED,
-    STATE_LOCKING,
-    STATE_UNLOCKED,
-    STATE_UNLOCKING,
-)
+from homeassistant.components.lock import LockState
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -48,42 +42,42 @@ class BlueConLock(LockEntity):
         self.accessDoor = accessDoor
         self._attr_unique_id = f'{self.lockId}_door_lock'.lower()
         self.entity_id = f'{DOMAIN}.{self._attr_unique_id}'.lower()
-        self._state = STATE_LOCKED
+        self._state = LockState.LOCKED
         self.__model = f'{deviceInfo.type} {deviceInfo.subType} {deviceInfo.family}',
         self.__lockTimeout = lockTimeout
     
     @property
     def is_locking(self) -> bool:
         """Return true if lock is locking."""
-        return self._state == STATE_LOCKING
+        return self._state == LockState.LOCKING
 
     @property
     def is_unlocking(self) -> bool:
         """Return true if lock is unlocking."""
-        return self._state == STATE_UNLOCKING
+        return self._state == LockState.UNLOCKING
 
     @property
     def is_jammed(self) -> bool:
         """Return true if lock is jammed."""
-        return self._state == STATE_JAMMED
+        return self._state == LockState.JAMMED
 
     @property
     def is_locked(self) -> bool:
         """Return true if lock is locked."""
-        return self._state == STATE_LOCKED
+        return self._state == LockState.LOCKED
 
     async def async_lock(self) -> None:
         pass
 
     async def async_unlock(self) -> None:
         """Unlock the device."""
-        self._state = STATE_UNLOCKING
+        self._state = LockState.UNLOCKING
         self.async_schedule_update_ha_state(True)
         await self.bluecon.openDoor(self.deviceId, self.accessDoor)
-        self._state = STATE_UNLOCKED
+        self._state = LockState.UNLOCKED
         self.async_schedule_update_ha_state(True)
         await asyncio.sleep(self.__lockTimeout)
-        self._state = STATE_LOCKED
+        self._state = LockState.LOCKED
         self.async_schedule_update_ha_state(True)
 
     async def async_open(self) -> None:

--- a/custom_components/bluecon/manifest.json
+++ b/custom_components/bluecon/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "bluecon",
     "name": "Fermax Blue",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "documentation": "https://hass-bluecon.afonsogarcia.dev/",
     "issue_tracker": "https://github.com/AfonsoFGarcia/hass-bluecon/issues",
     "requirements": ["bluecon==0.4.3", "aiohttp", "aiohttp", "rustPlusPushReceiver", "python-dateutil"],

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "HASS-BlueCon",
   "render_readme": true,
   "hide_default_branch": false,
-  "homeassistant": "2024.10.0"
+  "homeassistant": "2025.10.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "HASS-BlueCon",
   "render_readme": true,
   "hide_default_branch": false,
-  "homeassistant": "2024.3.0"
+  "homeassistant": "2024.10.0"
 }


### PR DESCRIPTION
The integration stopped working after the 2025.10 upgrade, as had been announced through deprecation warnings in previous versions. This PR now uses the new LockState enum.